### PR TITLE
Fix ESLint 9 compatibility

### DIFF
--- a/lib/rules/granular-selectors.js
+++ b/lib/rules/granular-selectors.js
@@ -750,7 +750,8 @@ module.exports = {
           if (reportedVariables[key]) return;
 
           // Find the declaration of the object
-          var scope = context.getScope();
+          var sourceCode = getSourceCodeSafely();
+          var scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
           var variable;
 
           for (

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:eslint5": "npm i eslint@5.16.0 mocha@5.2.0 --no-save && npm test",
     "test:eslint6": "npm i eslint@6.8.0 mocha@7.2.0 --no-save && npm test",
     "test:eslint7": "npm i eslint@7.32.0 mocha@8.4.0 --no-save && npm test",
-    "test:eslint8": "npm i eslint@8.38.0 mocha@10.2.0 --no-save && npm test"
+    "test:eslint8": "npm i eslint@8.38.0 mocha@10.2.0 --no-save && npm test",
+    "test:eslint9": "npm i eslint@9.31.0 mocha@10.2.0 --no-save && npm test"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
- Replace context.getScope() with sourceCode.getScope(node) for ESLint 9+ compatibility
- Add backwards compatibility for ESLint 5-8 using fallback to context.getScope()
- Update RuleTester configuration to support flat config format in ESLint 9+
- Add test:eslint9 script for testing with ESLint 9.31.0
- Maintain support for eslintrc format in older ESLint versions
- Fix TypeScript parser usage to eliminate unused variables
- All tests passing across ESLint 5.16.0 through 9.31.0

Fixes #1